### PR TITLE
Fix some problems when building documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,4 +22,5 @@ All codes, 3D models, and PCB designs are available at the project's GitHub repo
    installation_arduino
    building_micromap
    building_headstage
-
+   modules/interface_functions
+   modules/user_interface

--- a/docs/source/modules/user_interface.rst
+++ b/docs/source/modules/user_interface.rst
@@ -6,6 +6,6 @@ This module contains functions that are used to display the data acquired by the
 These functions are dealing with the interface as a whole. TIn other words, they contain the front-end in which the user will be able 
 to choose the acquisition parameters such as sampling frequency, filters and number of channels active during the acquisition.
 
-.. automodule:: micromap.interface.interface_visual
+.. automodule:: micromap.interface.user_interface
    :members:
    :show-inheritance:

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
 
 [options.entry_points]
 console_scripts= 
-    micromap=micromap.interface.interface_visual:main
+    micromap=micromap.interface.user_interface:main
 
 [options.packages.find]
 where=src

--- a/src/micromap/interface/tempCodeRunnerFile.py
+++ b/src/micromap/interface/tempCodeRunnerFile.py
@@ -1,1 +1,0 @@
-self.timeout

--- a/src/micromap/interface/user_interface.py
+++ b/src/micromap/interface/user_interface.py
@@ -25,7 +25,7 @@ import serial.tools.list_ports
 import time
 import struct
 import queue
-import interface_functions as interface_functions      
+from . import interface_functions as interface_functions      
 import os
 import platform
 import pickle


### PR DESCRIPTION
- "ModuleNotFoundError: No module named 'interface_functions'\n"] [autodoc.import_object]
    - Fixed by renaming interface_visual to "user_interface" to reflect the name of the current source file and changing the import statement to from . import interface_functions as interface_functions.
        - Note: By doing this the program cannot be run by using user_interface.py as a single script, as it throws an error (no parent package). This is fixed bu running the interface as python -m micromap.interface.user_interface from the uppermost directory (i.e.: ./src)

- Fixed inconsistency problems:
    - WARNING: document isn't included in any toctree [toc.not_included]
    - WARNING: document isn't included in any toctree [toc.not_included]
    - This was done by adding thse files in the index.rst
        - modules/interface_functions
        - modules/user_interface

- Change entry point:

[options.entry_points]
console_scripts=
    micromap=micromap.interface.user_interface:main

- Delete temporary python source file